### PR TITLE
fix: remove postinstall script to fix NPM package installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@secforge/ios-simulator-mcp",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "MCP server for interacting with iOS simulators locally or remotely via SSH",
   "bin": {
     "ios-simulator-mcp": "./build/index.js"
@@ -15,7 +15,6 @@
   ],
   "scripts": {
     "prepare": "npm run build",
-    "postinstall": "npm run build",
     "build": "tsc && node -e \"require('fs').chmodSync('build/index.js', '755')\"",
     "start": "node build/index.js",
     "watch": "tsc --watch",


### PR DESCRIPTION
## Problem
The NPM package @secforge/ios-simulator-mcp@1.5.1 fails to install via npx with 'command not found' error.

## Root Cause
The `postinstall` script tries to rebuild TypeScript files on the user's machine, but:
- TypeScript is only a devDependency
- Source .ts files are not included in the package
- This causes installation to fail

## Solution
Remove the `postinstall` script. The build files are already included in the NPM package, so no rebuild is needed.

## Testing
After this fix, `npx @secforge/ios-simulator-mcp` will work correctly.

Fixes the installation issue reported when using:
```bash
claude mcp add ios-simulator npx @secforge/ios-simulator-mcp
```