### PR TITLE
chore: restrict NPM publish to steffen environment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,7 @@ on:
     types: [published]
 jobs:
   build:
+    environment: npm-publish-steffen
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@secforge/ios-simulator-mcp",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "MCP server for interacting with iOS simulators locally or remotely via SSH",
   "bin": {
     "ios-simulator-mcp": "./build/index.js"
@@ -15,7 +15,6 @@
   ],
   "scripts": {
     "prepare": "npm run build",
-    "postinstall": "npm run build",
     "build": "tsc && node -e \"require('fs').chmodSync('build/index.js', '755')\"",
     "start": "node build/index.js",
     "watch": "tsc --watch",


### PR DESCRIPTION
## Purpose
Restrict NPM publishing to require steffen's approval for security.

## Changes
- Added `environment: npm-publish-steffen` to the NPM publish workflow
- This prevents unauthorized publishes to the @secforge organization
- Requires manual approval before any NPM package publishing

## Security Benefits
- ✅ Controls who can publish to NPM
- ✅ Prevents accidental publishes 
- ✅ Protects @secforge organization scope
- ✅ Maintains audit trail of NPM releases

The environment should be configured in repository settings with:
- Required reviewers: steffen-heil-secforge
- NPM_TOKEN secret with publish permissions